### PR TITLE
Example shiny application modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,9 @@ vignettes/*.pdf
 *.utf8.md
 *.knit.md
 
+# Temporary files created by VIM
+*.swo
+*.swp
+
 # R Environment Variables
 .Renviron

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     fs,
     magrittr,
     shiny,
+    shinyjs,
     shinyFiles,
     stringr,
     striprtf,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     fs,
     magrittr,
     shiny,
+    shinyFiles,
     stringr,
     striprtf,
     tibble

--- a/inst/shiny_examples/app/app.R
+++ b/inst/shiny_examples/app/app.R
@@ -4,11 +4,15 @@
 #'
 #'
 
-custom_file_input <- function (input_id, label, value = "", ...) {
-  div(class = "form-group form-group-custom shiny-input-container",
-    shinyFiles::shinyDirButton(paste0(input_id, "_directory"), NULL, "Please select a folder", icon = icon("folder-open")),
-    tags$label(label, `for` = input_id, class = "control-label"),
-    tags$input(id = input_id, type = "text", class = "shiny-input-text form-control shiny-bound-input", value = value, ...),
+custom_file_input <- function(input_id, label, value = "", ...) {
+  label_class  <- "control-label"
+  input_class  <- "shiny-input-text form-control shiny-bound-input"
+  folder_value <- system.file(value, package = "verifyr")
+
+  shiny::div(class = "form-group form-group-custom shiny-input-container",
+    shinyFiles::shinyDirButton(paste0(input_id, "_select"), NULL, "Select folder", icon = shiny::icon("folder-open")),
+    tags$label(label, `for` = input_id, class = label_class),
+    tags$input(id = input_id, type = "text", class = input_class, value = folder_value, ...),
   )
 }
 
@@ -18,8 +22,8 @@ ui <- shiny::fluidPage(
   shiny::wellPanel(
     shiny::fluidRow(
       shiny::column(6,
-        custom_file_input("old_file_location", "Old File Folder", system.file("/extdata/base_files", package = "verifyr")),
-        custom_file_input("new_file_location", "New File Folder", system.file("/extdata/compare_files", package = "verifyr")),
+        custom_file_input("old_folder", "Old File Folder", "/extdata/base_files"),
+        custom_file_input("new_folder", "New File Folder", "/extdata/compare_files"),
         shiny::actionButton("go", "Go")
       ),
       shiny::column(6,
@@ -43,49 +47,47 @@ ui <- shiny::fluidPage(
 )
 server <- function(input, output, session) {
 
-  roots <- c(Home = fs::path_home(), Examples = fs::path_package("verifyr", "extdata"))
+  roots  <- c(Home = fs::path_home(), Examples = fs::path_package("verifyr", "extdata"))
+  params <- list(roots = roots, session = session, restrictions = system.file(package = "base"), allowDirCreate = FALSE)
 
-  shinyFiles::shinyDirChoose(input, "old_file_location_directory", roots = roots, session = session, restrictions = system.file(package = "base"), allowDirCreate = FALSE)
-  shinyFiles::shinyDirChoose(input, "new_file_location_directory", roots = roots, session = session, restrictions = system.file(package = "base"), allowDirCreate = FALSE)
+  do.call(shinyFiles::shinyDirChoose, c(list(input, "old_folder_select"), params))
+  do.call(shinyFiles::shinyDirChoose, c(list(input, "new_folder_select"), params))
 
-  initial_out_placeholder_text <- reactiveVal('Select the compared file folders and execute the initial comparison by clicking on the "Go" button.')
-  full_out_placeholder_text    <- reactiveVal('Click on a row in the initial comparison result to view the detailed side-by-side comparison.')
+  default1 <- "Select the compared file folders and execute the initial comparison by clicking on the 'Go' button."
+  initial_out_placeholder_text <- shiny::reactiveVal(default1)
+
+  default2 <- "Click on a row in the initial comparison result to view the detailed side-by-side comparison."
+  full_out_placeholder_text <- shiny::reactiveVal(default2)
 
   shiny::observe({
-    if (!is.integer(input$old_file_location_directory)) {
-      shiny::updateTextInput(session, "old_file_location",
-        label <- NULL,
-        value <- parseDirPath(roots, input$old_file_location_directory)
+    if (!is.integer(input$old_folder_select)) {
+      shiny::updateTextInput(session, "old_folder",
+        NULL,
+        shinyFiles::parseDirPath(roots, input$old_folder_select)
       )
     }
 
-    if (!is.integer(input$new_file_location_directory)) {
-      shiny::updateTextInput(session, "new_file_location",
-        label <- NULL,
-        value <- shinyFiles::parseDirPath(roots, input$new_file_location_directory)
+    if (!is.integer(input$new_folder_select)) {
+      shiny::updateTextInput(session, "new_folder",
+        NULL,
+        shinyFiles::parseDirPath(roots, input$new_folder_select)
       )
     }
   })
 
   list_of_files <- shiny::eventReactive(input$go, {
-    if (file.exists(input$old_file_location) && file.exists(input$new_file_location)) {
-      initial_out_placeholder_text('') 
-      verifyr::list_files(input$old_file_location, input$new_file_location, input$file_name_patter)
+    if (file.exists(input$old_folder) && file.exists(input$new_folder)) {
+      initial_out_placeholder_text("")
+      verifyr::list_files(input$old_folder, input$new_folder, input$file_name_patter)
     }
   })
 
   initial_verify <- shiny::reactive({
     if (!is.null(list_of_files())) {
       tibble::tibble(list_of_files()) %>%
-      dplyr::mutate(omitted = input$omit_rows) %>%
-      dplyr::rowwise() %>%
-      dplyr::mutate(comparison = verifyr::initial_comparison(old =old_path,new=new_path, omit = omitted))
-    }
-  })
-
-  full_verify <- shiny::reactive({
-    if (file.exists(input$old_file_location) && file.exists(input$new_file_location)) {
-      verifyr::full_comparison(input$old_file_location, input$new_file_location)
+        dplyr::mutate(omitted = input$omit_rows) %>%
+        dplyr::rowwise() %>%
+        dplyr::mutate(comparison = verifyr::initial_comparison(old =old_path,new=new_path, omit = omitted)) # nolint
     }
   })
 
@@ -99,22 +101,27 @@ server <- function(input, output, session) {
 
   shiny::observe({
     shiny::req(input$initial_out_rows_selected)
-    selRow <- initial_verify()[input$initial_out_rows_selected,]
-    full_out_placeholder_text('') 
+    sel_row <- initial_verify()[input$initial_out_rows_selected, ]
+    full_out_placeholder_text("")
 
     #list side-by-side comparison
     output$full_out <- shiny::renderUI({
       shiny::HTML(
         as.character(
-          verifyr::full_comparison(paste0(selRow[2]), paste0(selRow[3]))
+          verifyr::full_comparison(paste0(sel_row[2]), paste0(sel_row[3]))
         )
       )
     })
   })
 
   # set up the reactive value bindings to default outputs
-  output$initial_out_placeholder <- renderText({ initial_out_placeholder_text() })
-  output$full_out_placeholder <- renderText({ full_out_placeholder_text() })
+  output$initial_out_placeholder <- shiny::renderText({
+    initial_out_placeholder_text()
+  })
+
+  output$full_out_placeholder <- shiny::renderText({
+    full_out_placeholder_text()
+  })
 }
 
 shiny::shinyApp(ui, server)

--- a/inst/shiny_examples/app/app.R
+++ b/inst/shiny_examples/app/app.R
@@ -4,77 +4,108 @@
 #'
 #'
 
+custom_file_input <- function (input_id, label, value = "", ...) {
+  div(class = "form-group shiny-input-container", style = "padding-right: 50px; position: relative; width: 100%;",
+    shinyFiles::shinyDirButton(paste0(input_id, "_directory"), NULL, "Please select a folder", style = "position: absolute; right: 0px; top: 25px;", icon = icon("folder-open")),
+    tags$label(label, `for` = input_id, class = "control-label"),
+    tags$input(id = input_id, type = "text", class = "shiny-input-text form-control shiny-bound-input", value = value, ...),
+  )
+}
+
 ui <- shiny::fluidPage(
   shiny::headerPanel("File Location Input"),
-  shiny::sidebarPanel(
-    shiny::textInput("old_file_location", "Old File Folder", paste0(system.file("/extdata/base_files", package = "verifyr"))),
-    shiny::textInput("new_file_location", "New File Folder", paste0(system.file("/extdata/compare_files", package = "verifyr"))),
-    shiny::textInput("file_name_patter", "File Name Pattern"),
-    shiny::textInput("omit_rows", "Omit rows with text", "Source:"),
-    shiny::actionButton("go", "Go")
+  shiny::wellPanel(
+    shiny::fluidRow(
+      shiny::column(6,
+        custom_file_input("old_file_location", "Old File Folder", system.file("/extdata/base_files", package = "verifyr")),
+        custom_file_input("new_file_location", "New File Folder", system.file("/extdata/compare_files", package = "verifyr")),
+        shiny::actionButton("go", "Go")
+      ),
+      shiny::column(6,
+        shiny::textInput("file_name_patter", "File Name Pattern"),
+        shiny::textInput("omit_rows", "Omit rows with text", "Source:"),
+      ),
+    ),
   ),
-  shiny::mainPanel(
-    h4("Initial comparison (using function initial_comparison):"),
-    DT::dataTableOutput("initial_out"),
-    h4("Side-by side comparison (using function full_comparison):"),
-    shiny::htmlOutput("full_out")
-
-  )
+  shiny::fluidRow(
+    shiny::column(12,
+      h2("Initial comparison (using function initial_comparison):"),
+      DT::dataTableOutput("initial_out"),
+    ),
+    shiny::column(12,
+      h2("Side-by side comparison (using function full_comparison):"),
+      shiny::htmlOutput("full_out")
+    ),
+  ),
+  style = "padding: 20px;",
 )
 
-server <- function(input, output) {
+server <- function(input, output, session) {
 
+  roots <- c(Home = fs::path_home(), Examples = fs::path_package("verifyr", "extdata"))
 
-list_of_files <- eventReactive(input$go, {
+  shinyFiles::shinyDirChoose(input, "old_file_location_directory", roots = roots, session = session, restrictions = system.file(package = "base"), allowDirCreate = FALSE)
+  shinyFiles::shinyDirChoose(input, "new_file_location_directory", roots = roots, session = session, restrictions = system.file(package = "base"), allowDirCreate = FALSE)
+
+  observe({
+    if (!is.integer(input$old_file_location_directory)) {
+      shiny::updateTextInput(session, "old_file_location",
+        label <- NULL,
+        value <- parseDirPath(roots, input$old_file_location_directory)
+      )
+    }
+
+    if (!is.integer(input$new_file_location_directory)) {
+      shiny::updateTextInput(session, "new_file_location",
+        label <- NULL,
+        value <- parseDirPath(roots, input$new_file_location_directory)
+      )
+    }
+  })
+
+  list_of_files <- shiny::eventReactive(input$go, {
     if (file.exists(input$old_file_location) && file.exists(input$new_file_location)) {
       verifyr::list_files(input$old_file_location, input$new_file_location, input$file_name_patter)
     }
   })
 
-initial_verify <- shiny::reactive({
-  if (!is.null(list_of_files())) {
-    tibble::tibble(list_of_files()) %>%
-    dplyr::mutate(omitted = input$omit_rows) %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(comparison = verifyr::initial_comparison(old =old_path,new=new_path, omit = omitted))
-  }
-})
-
-full_verify <- shiny::reactive({
-  if (file.exists(input$old_file_location) && file.exists(input$new_file_location)) {
-    verifyr::full_comparison(input$old_file_location, input$new_file_location)
-  }
-})
-
-
-output$initial_out <-  DT::renderDataTable({
-  if (!is.null(initial_verify())) {
-    DT::datatable(initial_verify(), selection = "single")
-  } else {
-    "No folder selected or folders do not exist"
-  }
-})
-
-
-
-shiny::observe({
-  shiny::req(input$initial_out_rows_selected)
-  selRow <- initial_verify()[input$initial_out_rows_selected,]
-  output$full_out <- shiny::renderUI({
-
-    #list side-by-side comparison
-    shiny::HTML(
-      as.character(
-
-        verifyr::full_comparison(paste0(selRow[2]), paste0(selRow[3]))
-      )
-    )
-
+  initial_verify <- shiny::reactive({
+    if (!is.null(list_of_files())) {
+      tibble::tibble(list_of_files()) %>%
+      dplyr::mutate(omitted = input$omit_rows) %>%
+      dplyr::rowwise() %>%
+      dplyr::mutate(comparison = verifyr::initial_comparison(old =old_path,new=new_path, omit = omitted))
+    }
   })
 
-})
+  full_verify <- shiny::reactive({
+    if (file.exists(input$old_file_location) && file.exists(input$new_file_location)) {
+      verifyr::full_comparison(input$old_file_location, input$new_file_location)
+    }
+  })
 
+  output$initial_out <-  DT::renderDataTable({
+    if (!is.null(initial_verify())) {
+      DT::datatable(initial_verify(), selection = "single")
+    } else {
+      "No folder selected or folders do not exist"
+    }
+  })
 
+  shiny::observe({
+    shiny::req(input$initial_out_rows_selected)
+    selRow <- initial_verify()[input$initial_out_rows_selected,]
+
+    output$full_out <- shiny::renderUI({
+
+    #list side-by-side comparison
+      shiny::HTML(
+        as.character(
+          verifyr::full_comparison(paste0(selRow[2]), paste0(selRow[3]))
+        )
+      )
+    })
+  })
 }
 
 shiny::shinyApp(ui, server)

--- a/inst/shiny_examples/app/styles.css
+++ b/inst/shiny_examples/app/styles.css
@@ -1,0 +1,20 @@
+.container-fluid {
+    padding: 20px !important;
+}
+
+.form-group-custom {
+    padding-right: 50px; 
+    position: relative; 
+    width: 100%;
+}
+
+.form-group-custom .shinyDirectories {
+    position: absolute; 
+    right: 0px; 
+    top: 25px;
+}
+
+#initial_out td:hover {
+    cursor: pointer;
+}
+

--- a/inst/shiny_examples/app/styles.css
+++ b/inst/shiny_examples/app/styles.css
@@ -14,7 +14,25 @@
     top: 25px;
 }
 
+#save_comments, #clear_comments {
+    margin-bottom: 20px;
+}
+
 #initial_out td:hover {
     cursor: pointer;
 }
 
+#initial_out td.selected_custom {
+    background-color: yellow;
+}
+
+.comparison_comments {
+    display: none;
+    margin-top: 20px;
+}
+
+#download_csv {
+    display: none;
+    margin-top: 10px;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
A number of updates and improvements for the example shiny application:

- changed the main layout so that the left panel was removed and thus the side-by-side comparison has more available width
- added folder select options along the folder input fields
- added an option to add comments to file comparison (below the side-by-side comparison)
- added an option to export the initial comparison results along with the entered comments as CSV
- added an option to open the compared files
- a number of smaller updates/changes/improvements (adding placeholder texts, separate style file, etc)